### PR TITLE
Cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.27)
 
-set(CMAKE_C_COMPILER "clang")
-set(CMAKE_CXX_COMPILER "clang++")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -freflection -fno-access-contexts -std=c++26")
-# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
 
 project(mppi
     VERSION 0.10.2

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,46 @@
+{
+  "version": 5,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 27,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "clang_reflection",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "26",
+        "CMAKE_CXX_STANDARD_REQUIRED": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/clang-p2996-libcxx.cmake"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "inherits": "clang_reflection",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "inherits": "clang_reflection",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ],
+
+  "buildPresets": [
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ Additionally, for the tests:
 
 To build, test and install the MPPI library execute
 ```shell
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/my/install/prefix ..
-make [-j N] 
-make install
+cmake --preset release -B build -S . -DCMAKE_INSTALL_PREFIX=/my/install/prefix ..
+cmake --build build
+cmake --install build
 ```
 
 ## Notes

--- a/cmake/toolchains/clang-p2996-libcxx.cmake
+++ b/cmake/toolchains/clang-p2996-libcxx.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+add_compile_options(-stdlib=libc++ -freflection)
+add_link_options(-stdlib=libc++)


### PR DESCRIPTION
Some Improvements around the cmake build system

- Use newer cmake version 3.2.27 that should be available when using C++23
- Make tests available for all build types and use CTest
- Do not enforece a specific build type in CMakeLists.txt
- Bump C++ version up to 26 for reflections
- Use CMake presets and toolchains instead of hard coding CMAKE variables
